### PR TITLE
Add fretboard systems

### DIFF
--- a/site/config.json
+++ b/site/config.json
@@ -1,6 +1,7 @@
 {
   "colors": {
     "defaultFill": "white",
+    "defaultActiveFill": "#F25116",
     "defaultStroke": "black",
     "disabled": "#aaa",
     "primaryFill": "#3273dc",

--- a/site/data/labels.json
+++ b/site/data/labels.json
@@ -5,6 +5,11 @@
     "author": "https://www.diegocaponera.com"
   },
   "examples": {
+    "systems": {
+      "title": "Examples / Systems",
+      "pentatonic": "Pentatonic system",
+      "caged": "CAGED System"
+    },
     "boxes": {
       "title": "Examples / Boxes",
       "connected": "Connected Boxes",

--- a/site/data/texts.md
+++ b/site/data/texts.md
@@ -69,3 +69,12 @@ Fretboard.js can render chord diagrams of course. Here you have some good old [o
 
 <!--examples.chords.jazz-->
 Want to become a jazz cat? No problem!
+
+<!--examples.systems.description-->
+The library supports the pentatonic and the CAGED scale systems.
+
+<!--examples.systems.pentatonic-->
+The pentatonic system is organised in five boxes. Here you can see the various ways of playing an **E minor pentatonic** scale across all the fretboard.
+
+<!--examples.systems.caged-->
+The CAGED system is organised in five boxes, named around the corresponding open chord shapes. Here the same **C major** scale is played in different positions.

--- a/site/pages/examples/systems.ejs
+++ b/site/pages/examples/systems.ejs
@@ -1,0 +1,66 @@
+<!doctype html>
+<html lang="en" class="has-navbar-fixed-top" data-section="systems">
+
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport"
+	  content="width=device-width, initial-scale=1">
+	<title><%= htmlWebpackPlugin.options.title %></title>
+	<%= htmlWebpackPlugin
+		.tags
+		.headTags
+		.filter((tag) => tag.attributes.href.startsWith('index'))
+		.join('')
+	%>
+</head>
+
+<body>
+	<%= partials.nav('systems') %>
+	<main>
+		<section class="container">
+			<header>
+				<h1><%= examples.systems.title %></h1>
+				<p>
+					<a href="<%= getExampleLink('systems') %>">See example source</a>
+				</p>				
+				<%= texts['examples.systems.description'] %>
+            </header>
+            <section>
+                <h2><%= examples.systems.pentatonic %></h2>
+                <div class="columns">
+                    <figure class="column is-three-quarters" id="fretboard-systems-pentatonic-minor"></figure>
+                    <aside class="column aside">
+                        <%= texts['examples.systems.pentatonic'] %>
+                        <p>
+                        <% [1,2,3,4,5].forEach(function(i){ %>
+                            <button data-pentatonic-box="<%= i %>"><%= i%></button>
+                        <%})%>
+                        </p>
+                    </aside>
+                </div>
+            </section>
+            <section>
+                <h2><%= examples.systems.caged %></h2>
+                <div class="columns">
+                    <figure class="column is-three-quarters" id="fretboard-systems-caged"></figure>
+                    <aside class="column aside">
+                        <%= texts['examples.systems.caged'] %>
+                        <p>
+                        <% ['C', 'A', 'G', 'E', 'D'].forEach(function(i){ %>
+                            <button data-caged-box="<%= i %>"><%= i%></button>
+                        <%})%>
+                        </p>
+                    </aside>
+                </div>
+            </section>            
+		</section>
+	</main>
+	<%= partials.footer() %>
+	<%= htmlWebpackPlugin
+		.tags
+		.bodyTags
+		.filter((tag) => tag.attributes.src.startsWith('index'))
+		.join('')
+	%>
+</body>
+</html>

--- a/site/scripts/examples/systems.js
+++ b/site/scripts/examples/systems.js
@@ -1,0 +1,101 @@
+import {
+  Fretboard,
+  CAGED,
+  FretboardSystem,
+  pentatonicMinor,
+  pentatonicMajor,
+  CAGEDSystem,
+} from "../../../dist/fretboard.esm.js";
+import { fretboardConfiguration, colors } from "../config.js";
+
+function pentatonicSystemExample() {
+  const system = new FretboardSystem();
+  const fretboard = new Fretboard({
+    ...fretboardConfiguration,
+    el: "#fretboard-systems-pentatonic-minor",
+    dotText: ({ note, octave, interval }) => note,
+    dotFill: ({ interval, disabled }) =>
+      disabled
+        ? colors.disabled
+        : interval === '1P'
+        ? colors.defaultActiveFill : colors.defaultFill,
+  });
+
+  const root = "E";
+  const mode = "minor";
+  const box = 1;
+
+  fretboard.render(
+    system.getScale({
+      name: `${root} ${mode} pentatonic`,
+      system: pentatonicMinor({
+        root,
+        box,
+      }),
+    })
+  );
+
+  document.querySelectorAll("[data-pentatonic-box").forEach((el) => {
+    el.addEventListener("click", () => {
+      const { pentatonicBox } = el.dataset;
+      fretboard.render(
+        system.getScale({
+          name: `${root} ${mode} pentatonic`,
+          system: pentatonicMinor({
+            root,
+            box: pentatonicBox,
+          }),
+        })
+      );
+    });
+  });
+}
+
+function CAGEDSystemExample() {
+  const system = new FretboardSystem();
+  const fretboard = new Fretboard({
+    ...fretboardConfiguration,
+    el: "#fretboard-systems-caged",
+    dotText: ({ note, octave, interval }) => note,
+    dotFill: ({ interval, disabled }) =>
+      disabled
+        ? colors.disabled
+        : interval === "1P"
+        ? colors.defaultActiveFill
+        : colors.defaultFill,
+  });
+
+  const root = "C";
+  const mode = "major";
+  const box = 'C';
+
+  fretboard.render(
+    system.getScale({
+      name: `${root} ${mode}`,
+      system: CAGEDSystem({
+        root,
+        box,
+      }),
+    })
+  );
+
+  document.querySelectorAll("[data-caged-box").forEach((el) => {
+    el.addEventListener("click", () => {
+      const { cagedBox } = el.dataset;
+      fretboard.render(
+        system.getScale({
+          name: `${root} ${mode}`,
+          system: CAGEDSystem({
+            root,
+            box: cagedBox,
+          }),
+        })
+      );
+    });
+  });
+}
+
+export default function systems() {
+    pentatonicSystemExample();
+    CAGEDSystemExample();
+}

--- a/site/scripts/examples/systems.js
+++ b/site/scripts/examples/systems.js
@@ -1,9 +1,7 @@
 import {
   Fretboard,
-  CAGED,
   FretboardSystem,
   pentatonicMinor,
-  pentatonicMajor,
   CAGEDSystem,
 } from "../../../dist/fretboard.esm.js";
 import { fretboardConfiguration, colors } from "../config.js";

--- a/site/scripts/index.js
+++ b/site/scripts/index.js
@@ -9,6 +9,7 @@ import boxes from './examples/boxes.js';
 import chords from './examples/chords.js';
 import events from './examples/events.js';
 import tetrachords from './examples/tetrachords.js';
+import systems from "./examples/systems.js";
 
 document.addEventListener('DOMContentLoaded', () => {
   ({
@@ -18,6 +19,7 @@ document.addEventListener('DOMContentLoaded', () => {
     chords,
     events,
     tetrachords,
+    systems,
     documentation: () => {}
   })[document.documentElement.dataset.section]();
 });

--- a/src/fretboardSystem/FretboardSystem.test.ts
+++ b/src/fretboardSystem/FretboardSystem.test.ts
@@ -1,0 +1,94 @@
+import test from 'ava';
+
+import {
+    FretboardSystem,
+    DEFAULT_GUITAR_TUNING,
+    DEFAULT_FRET_COUNT,
+} from './FretboardSystem';
+
+test('FretboardSystem - constructor with default options', t => {
+    const system = new FretboardSystem();
+    t.is(system instanceof FretboardSystem, true);
+    t.is(system.getTuning(), DEFAULT_GUITAR_TUNING);
+    t.is(system.getFrets(), DEFAULT_FRET_COUNT);
+});
+
+test('FretboardSystem - constructor with custom options', t => {
+    const customParams = {
+        tuning: ['G2', 'B2', 'D3', 'G3', 'B3', 'D4'],
+        frets: 12
+    };
+    const system = new FretboardSystem(customParams);
+    t.is(system instanceof FretboardSystem, true);
+    t.is(system.getTuning(), customParams.tuning);
+    t.is(system.getFrets(), customParams.frets);
+});
+
+test('FretboardSystem - getScale()', t => {
+    const system = new FretboardSystem();
+    const scale = system.getScale({
+        name: 'E minor pentatonic',
+    });
+    t.deepEqual(scale[0], {
+        octave: 4,
+        disabled: false,
+        chroma: 4,
+        note: 'E',
+        interval: '1P',
+        degree: 1,
+        string: 1,
+        fret: 0
+    });
+});
+
+test('FretboardSystem - getScale() - scale not found', t => {
+    const system = new FretboardSystem();
+    const error = t.throws(() => {
+        system.getScale({
+            name: 'H augmented pentatronic',
+        });
+    });
+    t.is(error.message, 'Cannot find scale: H augmented pentatronic');
+});
+
+test('FretboardSystem - getScale() with system', t => {
+    const system = new FretboardSystem();
+    const scale = system.getScale({
+        name: 'E minor pentatonic',
+        system: [0, 3]
+    });
+    t.is(
+        scale.filter(({ disabled }) => !disabled).length,
+        12
+    );
+});
+
+test('FretboardSystem - getScale() - B#', t => {
+    const system = new FretboardSystem({ frets: 12 });
+    const scale = system.getScale({ name: 'B# major' });
+    scale
+        .map(({ note, octave }, index) => note === 'B#' ?  { octave, index }: null)
+        .filter(x => !!x)
+        .forEach(({ octave, index }) => {
+            const { octave: nextOctave, fret} = scale[index + 1];
+            if (!nextOctave || fret === 0 || fret === 12) {
+                return;
+            }
+            t.is(octave, (nextOctave as number) - 1);
+        })
+});
+
+test('FretboardSystem - getScale() - Cb', t => {
+    const system = new FretboardSystem({ frets: 12 });
+    const scale = system.getScale({ name: 'Cb major' });
+    scale
+        .map(({ note, octave }, index) => note === 'Cb' ? { octave, index } : null)
+        .filter(x => !!x)
+        .forEach(({ octave, index }) => {
+            const { octave: prevOctave, fret } = scale[index - 1];
+            if (!prevOctave || fret === 0 || fret === 12) {
+                return;
+            }
+            t.is(octave, (prevOctave as number) + 1);
+        })
+});

--- a/src/fretboardSystem/FretboardSystem.test.ts
+++ b/src/fretboardSystem/FretboardSystem.test.ts
@@ -6,6 +6,8 @@ import {
     DEFAULT_FRET_COUNT,
 } from './FretboardSystem';
 
+import { pentatonicMinor } from './systems/systems';
+
 test('FretboardSystem - constructor with default options', t => {
     const system = new FretboardSystem();
     t.is(system instanceof FretboardSystem, true);
@@ -55,7 +57,10 @@ test('FretboardSystem - getScale() with system', t => {
     const system = new FretboardSystem();
     const scale = system.getScale({
         name: 'E minor pentatonic',
-        system: [0, 3]
+        system: pentatonicMinor({
+            root: 'E',
+            box: 1
+        })
     });
     t.is(
         scale.filter(({ disabled }) => !disabled).length,

--- a/src/fretboardSystem/FretboardSystem.ts
+++ b/src/fretboardSystem/FretboardSystem.ts
@@ -2,7 +2,6 @@ import { get as getNote, chroma as getChroma } from '@tonaljs/note';
 import { get as getScale } from '@tonaljs/scale';
 
 import { Position } from '../fretboard/Fretboard';
-import { BoxBounds } from './systems/systems';
 
 export type FretboardPosition = {
     string: number;
@@ -38,7 +37,7 @@ export class FretboardSystem {
         system
     }: {
         name: string;
-        system?: BoxBounds;
+        system?: (p: Position) => boolean;
     }): Position[] {
         const { notes, empty, intervals } = getScale(name);
         if (empty) {
@@ -58,7 +57,7 @@ export class FretboardSystem {
             }))
             .map(x => ({
                 octave: this.getOctave(x),
-                disabled: system ? (x.fret < system[0] || x.fret > system[1]) : false,
+                disabled: system ? !system(x) : false,
                 ...x
             }));
     }    

--- a/src/fretboardSystem/FretboardSystem.ts
+++ b/src/fretboardSystem/FretboardSystem.ts
@@ -1,0 +1,102 @@
+import { get as getNote, chroma as getChroma } from '@tonaljs/note';
+import { get as getScale } from '@tonaljs/scale';
+
+import { Position } from '../fretboard/Fretboard';
+import { BoxBounds } from './systems/systems';
+
+export type FretboardPosition = {
+    string: number;
+    fret: number;
+    chroma: number;
+}
+
+export type Tuning = string[];
+export const DEFAULT_GUITAR_TUNING = ['E2', 'A2', 'D3', 'G3', 'B3', 'E4'];
+export const DEFAULT_FRET_COUNT = 15;
+
+type FretboardSystemParams = {
+    tuning?: Tuning;
+    frets?: number;
+}
+
+export class FretboardSystem {
+    private tuning: Tuning = DEFAULT_GUITAR_TUNING;
+    private frets: number = DEFAULT_FRET_COUNT;
+    private positions: FretboardPosition[];
+    constructor(params?: FretboardSystemParams) {
+        Object.assign(this, params);
+        this.populate();
+    }
+    getTuning(): Tuning {
+        return this.tuning;
+    }
+    getFrets(): number {
+        return this.frets;
+    }
+    getScale({
+        name,
+        system
+    }: {
+        name: string;
+        system?: BoxBounds;
+    }): Position[] {
+        const { notes, empty, intervals } = getScale(name);
+        if (empty) {
+            throw new Error(`Cannot find scale: ${name}`);
+        }
+        const reverseMap = notes.map((note, index) => ({
+            chroma: getChroma(note),
+            note,
+            interval: intervals[index],
+            degree: + intervals[index][0]
+        }));
+        return this.positions
+            .filter(({ chroma }) => reverseMap.find(x => x.chroma === chroma))
+            .map(({ chroma, ...rest }) => ({
+                ...reverseMap.find(x => x.chroma === chroma),
+                ...rest
+            }))
+            .map(x => ({
+                octave: this.getOctave(x),
+                disabled: system ? (x.fret < system[0] || x.fret > system[1]) : false,
+                ...x
+            }));
+    }    
+    private populate(): void {
+        const { tuning, frets } = this;
+        this.positions = tuning
+            .slice().reverse()
+            .reduce((memo, note, index) => {
+                const string = index + 1;
+                const { chroma } = getNote(note);
+                const filledString = Array.from(
+                    { length: frets + 1 },
+                    (_, fret) => ({
+                        string,
+                        fret,
+                        chroma: (chroma + fret) % 12
+                    })
+                );
+                return [...memo, ...filledString];
+            }, []);
+    }
+    private getOctave({ fret, string, chroma, note }: {
+        fret: number;
+        string: number;
+        note: string;
+        chroma: number;        
+    }): number {
+        const { tuning } = this;
+        const baseNoteWithOctave = tuning[tuning.length - string];
+        const baseChroma = getChroma(baseNoteWithOctave.slice(0, -1));
+        const baseOctave = +baseNoteWithOctave.slice(-1);
+        let octaveIncrement = chroma < baseChroma ? 1 : 0;
+        if (note === 'B#' && octaveIncrement > 0) {
+            octaveIncrement--;
+        } else if (note === 'Cb' && octaveIncrement === 0) {
+            octaveIncrement++;
+        }
+        octaveIncrement += Math.floor(fret / 12);
+        return baseOctave + octaveIncrement;
+    }
+}

--- a/src/fretboardSystem/systems/systems.test.ts
+++ b/src/fretboardSystem/systems/systems.test.ts
@@ -1,0 +1,52 @@
+import test from 'ava';
+
+import {
+    pentatonicMinor,
+    pentatonicMajor,
+    CAGEDSystem
+} from './systems';
+
+test('pentatonic minor system', t => {
+    const system = pentatonicMinor({
+        root: 'E',
+        box: 1
+    });
+    t.is(system({ string: 6, fret: 3 }), true);
+    t.is(system({ string: 6, fret: 4 }), false);
+});
+
+test('pentatonic major system', t => {
+    const system = pentatonicMajor({
+        root: 'G',
+        box: 1
+    });
+    t.is(system({ string: 6, fret: 3 }), true);
+    t.is(system({ string: 3, fret: 0 }), false);
+});
+
+test('CAGED system', t => {
+    const system = CAGEDSystem({
+        root: 'C',
+        box: 'A'
+    });
+    t.is(system({ string: 6, fret: 3 }), true);
+    t.is(system({ string: 2, fret: 1 }), false);
+});
+
+test('CAGED system - box not found', t => {
+    const error = t.throws(() => CAGEDSystem({
+        root: 'E',
+        box: 'H'
+    }));
+
+    t.is(error.message, 'Cannot find box H in the CAGED system');
+});
+
+test('pentatonic system - box not found', t => {
+    const error = t.throws(() => pentatonicMinor({
+        root: 'E',
+        box: 6
+    }));
+
+    t.is(error.message, 'Cannot find box 6 in the E minor pentatonic scale system');
+});

--- a/src/fretboardSystem/systems/systems.ts
+++ b/src/fretboardSystem/systems/systems.ts
@@ -1,0 +1,132 @@
+import { chroma as getChroma } from '@tonaljs/note';
+export type BoxBounds = [number, number];
+
+type PentatonicScaleDefinition = {
+    boxes: BoxBounds[];
+    mode: 'minor'|'major';
+    baseChroma: number;
+}
+
+type CAGEDScaleDefinition = {
+    box: BoxBounds;
+    baseChroma: number;
+}
+
+type SystemParams = {
+    root: string;
+    box: number;
+}
+
+const CAGEDDefinition: { [key: string]: CAGEDScaleDefinition } = {
+    E: {
+        box: [7, 10],
+        baseChroma: 0
+    },
+    A: {
+        box: [2, 6],
+        baseChroma: 0
+    },
+    G: {
+        box: [4, 8],
+        baseChroma: 0
+    },
+    C: {
+        box: [0, 3],
+        baseChroma: 0
+    },
+    D: {
+        box: [9, 13],
+        baseChroma: 0
+    }
+}
+
+const pentatonicMinorDefinition: PentatonicScaleDefinition = {
+    boxes: [
+        [0, 3],
+        [2, 5],
+        [4, 8],
+        [7, 10],
+        [9, 12]        
+    ],
+    mode: 'minor',
+    baseChroma: 4
+}
+
+const pentatonicMajorDefinition: PentatonicScaleDefinition = {
+    boxes: [
+        [2, 5],
+        [4, 8],
+        [7, 10],
+        [9, 12],
+        [0, 3],        
+    ],
+    mode: 'major',
+    baseChroma: 7
+}
+
+function getBoxBounds({
+    root,
+    box,
+    baseChroma
+}: {
+    root: string;
+    box: BoxBounds;
+    baseChroma: number;
+}): BoxBounds {
+    const delta = (getChroma(root) - baseChroma + 12) % 12;
+    const [lowerBound, upperBound] = box;
+    const increment = lowerBound + delta >= 12 ? delta - 12 : delta;
+    return [
+        lowerBound + increment,
+        upperBound + increment
+    ];
+}
+
+function pentatonic({
+    root,
+    box,
+    mode,
+    boxes,
+    baseChroma
+}: {
+    root: string;
+    box: number;
+    mode: string;
+    boxes: BoxBounds[];
+    baseChroma: number;
+}): BoxBounds {
+    const foundBox = boxes[box - 1];
+    if (!foundBox) {
+        throw new Error(`Cannot find box ${box} in the ${root} ${mode} pentatonic scale system`);
+    }
+    return getBoxBounds({
+        root,
+        box: foundBox,
+        baseChroma
+    });
+}
+
+export function pentatonicMinor(params: SystemParams): BoxBounds {
+    return pentatonic({
+        ...params,
+        ...pentatonicMinorDefinition
+    });
+}
+
+export function pentatonicMajor(params: SystemParams): BoxBounds {
+    return pentatonic({
+        ...params,
+        ...pentatonicMajorDefinition
+    });
+}
+
+export function CAGEDSystem({ root, box }: SystemParams): BoxBounds {
+    const foundBox = CAGEDDefinition[box];
+    if (!foundBox) {
+        throw new Error(`Cannot find box ${box} in the ${root} CAGED system`);
+    }
+    return getBoxBounds({
+        root,
+        ...foundBox
+    });
+}

--- a/src/fretboardSystem/systems/systems.ts
+++ b/src/fretboardSystem/systems/systems.ts
@@ -16,7 +16,7 @@ type CAGEDScaleDefinition = {
 
 type SystemParams = {
     root: string;
-    box: number;
+    box: number|string;
 }
 
 const CAGEDDefinition: { [key: string]: CAGEDScaleDefinition } = {
@@ -112,16 +112,18 @@ function pentatonic({
     });
 }
 
-export function pentatonicMinor(params: SystemParams): (p: Position) => boolean {
+export function pentatonicMinor({ box, ...params }: SystemParams): (p: Position) => boolean {
     const bounds = pentatonic({
+        box: +box,
         ...params,
         ...pentatonicMinorDefinition
     });
     return (position: Position): boolean => isPositionInSystem(position, bounds);
 }
 
-export function pentatonicMajor(params: SystemParams): (p: Position) => boolean {
+export function pentatonicMajor({ box, ...params }: SystemParams): (p: Position) => boolean {
     const bounds = pentatonic({
+        box: +box,
         ...params,
         ...pentatonicMajorDefinition
     });
@@ -131,7 +133,7 @@ export function pentatonicMajor(params: SystemParams): (p: Position) => boolean 
 export function CAGEDSystem({ root, box }: SystemParams): (p: Position) => boolean {
     const foundBox = CAGEDDefinition[box];
     if (!foundBox) {
-        throw new Error(`Cannot find box ${box} in the ${root} CAGED system`);
+        throw new Error(`Cannot find box ${box} in the CAGED system`);
     }
     const bounds = getBoxBounds({
         root,

--- a/src/fretboardSystem/systems/systems.ts
+++ b/src/fretboardSystem/systems/systems.ts
@@ -1,5 +1,7 @@
 import { chroma as getChroma } from '@tonaljs/note';
-export type BoxBounds = [number, number];
+import { Position } from '../../fretboard/Fretboard';
+
+type BoxBounds = [number, number];
 
 type PentatonicScaleDefinition = {
     boxes: BoxBounds[];
@@ -19,7 +21,7 @@ type SystemParams = {
 
 const CAGEDDefinition: { [key: string]: CAGEDScaleDefinition } = {
     E: {
-        box: [7, 10],
+        box: [7, 11],
         baseChroma: 0
     },
     A: {
@@ -64,6 +66,10 @@ const pentatonicMajorDefinition: PentatonicScaleDefinition = {
     baseChroma: 7
 }
 
+function isPositionInSystem({ fret }: Position, bounds: BoxBounds): boolean {
+    return fret >= bounds[0] && fret <= bounds[1];
+}
+
 function getBoxBounds({
     root,
     box,
@@ -106,27 +112,30 @@ function pentatonic({
     });
 }
 
-export function pentatonicMinor(params: SystemParams): BoxBounds {
-    return pentatonic({
+export function pentatonicMinor(params: SystemParams): (p: Position) => boolean {
+    const bounds = pentatonic({
         ...params,
         ...pentatonicMinorDefinition
     });
+    return (position: Position): boolean => isPositionInSystem(position, bounds);
 }
 
-export function pentatonicMajor(params: SystemParams): BoxBounds {
-    return pentatonic({
+export function pentatonicMajor(params: SystemParams): (p: Position) => boolean {
+    const bounds = pentatonic({
         ...params,
         ...pentatonicMajorDefinition
     });
+    return (position: Position): boolean => isPositionInSystem(position, bounds);
 }
 
-export function CAGEDSystem({ root, box }: SystemParams): BoxBounds {
+export function CAGEDSystem({ root, box }: SystemParams): (p: Position) => boolean {
     const foundBox = CAGEDDefinition[box];
     if (!foundBox) {
         throw new Error(`Cannot find box ${box} in the ${root} CAGED system`);
     }
-    return getBoxBounds({
+    const bounds = getBoxBounds({
         root,
         ...foundBox
     });
+    return (position: Position): boolean => isPositionInSystem(position, bounds);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,3 +10,10 @@ export {
   disableDots,
   sliceBox
 } from './scales/tools';
+
+export { FretboardSystem } from './fretboardSystem/FretboardSystem';
+export {
+  CAGEDSystem,
+  pentatonicMinor,
+  pentatonicMajor
+} from './fretboardSystem/systems/systems';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,7 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const targetPath = path.resolve(__dirname, '_site');
 
 const documentation = ['fretboard', 'musicTools'];
-const examples = ['boxes', 'modes', 'chords', 'tetrachords', 'events'];
+const examples = ['systems', 'boxes', 'modes', 'chords', 'tetrachords', 'events'];
 
 const labels = require('./site/data/labels.json');
 const textsFile = fs.readFileSync('./site/data/texts.md', 'utf8');


### PR DESCRIPTION
This is an intermediate step between the current state of things, and a sooner (better) API approach that prefers interaction from the `Fretboard` object itself.

The support for isolated boxes is still there, but now one can populate all the fretboard with a scale, and highlight the desired box (1-5 for pentatonic and C-A-G-E-D).

The scales are generated via [@tonaljs/scale][tonal], so what can be passed is extremely flexible.

**Bonus**: since the fretboard is populated on a string basis, one can pass custom tunings (whether they make sense or not, is user responsibility ^^).

## Render scale over all the fretboard

```js
import {
  Fretboard,
  FretboardSystem,
  pentatonicMinor
} from "@moonwave99/fretboard.js";

const system = new FretboardSystem();
const fretboard = new Fretboard();
const scale = system.getScale({ name: 'E minor pentatonic' });

fretboard.render(scale);
```

This populates the fretboard with all the E, G, A, B, D notes:

<img width="880" alt="Screenshot 2020-12-16 at 12 36 17" src="https://user-images.githubusercontent.com/380184/102343825-55fc2200-3f9b-11eb-8de7-2784c919254b.png">

## Custom tuning and fretboard length

```js
const system = new FretboardSystem({
  tuning: ['D2', 'G2', 'D3', 'G3', 'B3', 'D4'],
  frets: 12
});
const fretboard = new Fretboard({
  fretCount: 12
});
const scale = system.getScale({ name: 'G major pentatonic' });

fretboard.render(scale);
```

This renders a G major pentatonic over a 12 fret tuned in open G:

<img width="881" alt="Screenshot 2020-12-16 at 12 39 14" src="https://user-images.githubusercontent.com/380184/102344155-c6a33e80-3f9b-11eb-88a3-3b85b51cb5e9.png">

[tonal]: https://github.com/tonaljs/tonal/tree/master/packages/scale

## Highlighting things

Since everything is in place, to highlight things is much simpler now:

```js
import {
  Fretboard,
  FretboardSystem,
  pentatonicMinor,
} from '@moonwave99/fretboard.js';

const system = new FretboardSystem();
const fretboard = new Fretboard({
    dotFill: ({ interval, disabled }) => disabled ? $disabledColor : $activeColor
});

const pentatonicSystem = pentatonicMinor({
    root: 'E',
    box: 1
}),

const scale = system.getScale({
    name: `E minor pentatonic`,
    system: pentatonicSystem
});

fretboard.render(scale);
```

By passing the `system` param to  `getScale`, all positions besides selected ones are disabled:

<img width="873" alt="Screenshot 2020-12-16 at 12 51 17" src="https://user-images.githubusercontent.com/380184/102345301-71682c80-3f9d-11eb-8880-21dbab638669.png">

Styling is still made manually in the `dotFill` method.

Btw `system` is just a `(p: Position) => boolean` function, one can pass any custom filter.

## Gotchas

The pentatonic/caged highlighting system works on hardcoded lower and upper vertical bounds, nothing too fancy. Some inconsistencies appear when plotting minor or more exotic scales in some CAGED boxes for instance.

If one would renderer all the chromatic scale for instance, AND highlight a pentatonic box, even the passing notes would be included (bonus for blues scale!).

By the way I do not find much didactical value in indulging over these two system much, pentatonic is very simple and caged is very limiting (at least for me - that's why I started working on this tool!), so I don't thing I will spend much more time in refining them. Any contribution is warmly welcome of course.

The 3NPS is not (yet) supported because some boxes spread diagonally and this approach would include duplicate notes. Luckily enough, 3NPS is the more consistent / algorithmic one, and one can implement a deterministic including function.

## Future roadmap

### Naming things

The current state is not quite satisfying, especially between Fretboard and FretboardSystem and Scale and System...it needs some time to isolate the single components responsibilities;

### Incorporating features in the main `Fretboard` class

At the beginning I wanted to keep things as low level as possible, but I realised how much repetition it involves to do all the styling / interaction.

A good approach would be to expose a basic level `render(positions: Position[])` method, and more refined `renderScale(scale: string).highlightBox(box: string)` features for instance.

### Update docs and examples

Once the integration proceeds, docs and code examples will be updated accordingly.