### PR TITLE
Draft barres rendering support.

### DIFF
--- a/site/data/documentation/fretboard.md
+++ b/site/data/documentation/fretboard.md
@@ -85,13 +85,13 @@ el                | string   | '#fretboard' | Container element selector
 tuning            | string[] | ["E2", "A2", "D3", "G3", "B3", "E4"] | Tuning of the instrument (see [tuning](#tuning))
 stringCount       | number   | 6            | Number of instrument strings to display
 stringWidth       | number \| \[number\]   | 1   | String line stroke width - an array of 6 numbers can be passed, e.g. `[1, 1, 1, 3, 4, 5]`
-stringColor       | string   | 'black'      | String color
+stringColor       | string   | '#666'      | String color
 fretCount         | number   | 15           | Number of frets to display
 fretWidth         | string   | 1            | Fret line stroke width
-fretColor         | string   | 'black'      | Fret color
+fretColor         | string   | '#666'      | Fret color
 nutWidth          | string   | 7            | Nut stroke width
-nutColor          | string   | 'black'      | Nut color
-middleFretColor   | string   | 'red'        | Middle fret color
+nutColor          | string   | '#666'      | Nut color
+middleFretColor   | string   | '#ff636c'        | Middle fret color
 middleFretWidth   | string   | 3            | Middle fret stroke width
 scaleFrets        | string   | true         | If `true`, spaces frets logarithmically, otherwise linear
 topPadding        | string   | 20           | Top padding (relative to SVG container)
@@ -101,7 +101,7 @@ rightPadding      | string   | 20           | Right padding
 height            | string   | 150          | SVG element height
 width             | string   | 960          | SVG element width
 dotSize           | string   | 20           | Dot diameter
-dotStrokeColor    | string   | 'black'      | Dot stroke color
+dotStrokeColor    | string   | '#555'      | Dot stroke color
 dotStrokeWidth    | string   | 2            | Dot stroke width
 dotTextSize       | string   | 12           | Dot text size
 dotFill           | string   | 'white'      | Dot fill color
@@ -114,6 +114,7 @@ fretNumbersColor  | string   | '#00000099'  | Fret numbers color
 font              | string   | 'Arial'      | Text font
 crop              | boolean  | false        | If `true`, crops the rendering. Must be used in conjunction with `fretCount`, so set it to a value enough to contain your diagram (3/4 for a chord, 5/6 for a scale box for instance)
 fretLeftPadding   | number   | 0            | Amount of empty frets to display before dots.
+barresColor       | string   | '#666'            | Amount of empty frets to display before dots.
 
 ## Fretboard API
 
@@ -239,7 +240,7 @@ For more information, see [Fretboard Systems][fretboard-systems].
 ### renderChord()
 
 ```typescript
-renderChord(chord: string): Fretboard
+renderChord(chord: string, barres? Barre | Barre[]): Fretboard
 ```
 
 Shorthand for rendering positions from a chord voicing string, e.g. `x32010` for a C Major in open position.
@@ -275,6 +276,41 @@ fretboard.renderChord('x7678x');
 ```
 
 **Note:** for frets above the 9th, the dash-splitted-notation should be used in order to prevent parsing ambiguity - for instance `10-x-10-10-8-x` for a `Dmadd11` chord.
+
+Barres are supported by passing either a single `Barre` parameter, or an array of them:
+
+```typescript
+// renders a F major in first position
+const fretboard = new Fretboard({
+  fretCount: 3,
+  showFretNumbers: false,
+  crop: true
+});
+
+fretboard.renderChord('133211', { fret: 1 });
+
+// renders a B minor in second position
+const fretboard = new Fretboard({
+  fretCount: 3,
+  showFretNumbers: false,
+  crop: true
+});
+
+fretboard.renderChord('x24432', { fret: 2, stringFrom: 5 });
+
+// renders a C major in third position
+const fretboard = new Fretboard({
+  fretCount: 3,
+  showFretNumbers: false,
+  crop: true
+});
+
+fretboard.renderChord('x35553', [
+  { fret: 3, stringFrom: 5 },
+  { fret: 5, stringFrom: 4, stringTo: 2 }
+]);
+```
+**Note:** `stringFrom` defaults to the lowest string, and `stringTo` to the first. Pass the "human" agreed value otherwise, e.g. 2 for the open B string, or 5 for the open A (in standard guitar tuning of course).
 
 ### muteStrings()
 

--- a/site/data/snippets.md
+++ b/site/data/snippets.md
@@ -29,4 +29,40 @@ fretboard.renderChord([
 // optional
 fretboard.muteStrings({ strings: [6] });
 ```
+
+Barres are supported by passing either a single `Barre` parameter, or an array of them:
+
+```typescript
+// renders a F major in first position
+const fretboard = new Fretboard({
+  fretCount: 3,
+  showFretNumbers: false,
+  crop: true
+});
+
+fretboard.renderChord('133211', { fret: 1 });
+
+// renders a B minor in second position
+const fretboard = new Fretboard({
+  fretCount: 3,
+  showFretNumbers: false,
+  crop: true
+});
+
+fretboard.renderChord('x24432', { fret: 2, stringFrom: 5 });
+
+// renders a C major in third position
+const fretboard = new Fretboard({
+  fretCount: 3,
+  showFretNumbers: false,
+  crop: true
+});
+
+fretboard.renderChord('x35553', [
+  { fret: 3, stringFrom: 5 },
+  { fret: 5, stringFrom: 4, stringTo: 2 }
+]);
+```
+**Note:** `stringFrom` defaults to the lowest string, and `stringTo` to the first. Pass the "human" agreed value otherwise, e.g. 2 for the open B string, or 5 for the open A (in standard guitar tuning of course).
+
 Providing chord positions by name is outside the scope of this library, as many resources already exist for that.

--- a/site/data/texts.md
+++ b/site/data/texts.md
@@ -49,6 +49,9 @@ Fretboard.js can render chord diagrams of course. Here you have some good old [o
 
 [open-chords]: https://en.wikipedia.org/wiki/Open_chord
 
+<!--examples.chords.barred-->
+Fingers shortage? Raise the bar!
+
 <!--examples.chords.jazz-->
 Want to become a jazz cat? No problem!
 

--- a/site/pages/examples/chords.ejs
+++ b/site/pages/examples/chords.ejs
@@ -54,7 +54,52 @@
 							data-chord="xx0232"></figure>
 					</div>
 				</div>
-			</section>
+			</section>			
+			<section class="example">
+				<header class="description"><%= texts['examples.chords.barred'] %></header>
+				<div class="chords columns">
+					<div class="column one-fifth">
+						<figure
+							data-name="F"
+							data-chord="133211"
+							data-barred="true"
+							data-crop="true"
+							data-show-fret-numbers="true"></figure>							
+					</div>					
+					<div class="column one-fifth">
+						<figure
+							data-name="Bm"
+							data-chord="x24432"
+							data-barred="true"
+							data-crop="true"
+							data-show-fret-numbers="true"></figure>
+					</div>
+					<div class="column one-fifth">
+						<figure
+							data-name="C"
+							data-chord="x35553"
+							data-barred="true"
+							data-crop="true"
+							data-show-fret-numbers="true"></figure>						
+					</div>
+					<div class="column one-fifth">
+						<figure
+							data-name="A7#9"
+							data-chord="575688"
+							data-barred="true"
+							data-crop="true"
+							data-show-fret-numbers="true"></figure>												
+					</div>
+					<div class="column one-fifth">
+						<figure
+							data-name="D6/9"
+							data-chord="x5445x"
+							data-barred="true"
+							data-crop="true"
+							data-show-fret-numbers="true"></figure>																		
+					</div>
+				</div>
+			</section>			
 			<section class="example">
 				<header class="description"><%= texts['examples.chords.jazz'] %></header>
 				<div class="chords columns">

--- a/site/scripts/examples/chords.js
+++ b/site/scripts/examples/chords.js
@@ -2,6 +2,50 @@ import { Fretboard } from '../../../dist/fretboard.esm.js';
 
 import { fretboardConfiguration, colors } from '../config.js';
 
+const barres = {
+  F: {
+    fret: 1,
+  },
+  Bm: {
+    fret: 2,
+    stringFrom: 5,
+  },
+  C: [
+    {
+      fret: 3,
+      stringFrom: 5,
+    },
+    {
+      fret: 5,
+      stringFrom: 4,
+      stringTo: 2,
+    },
+  ],
+  'A7#9': [{
+    fret: 5,
+    stringTo: 4
+  }, {
+    fret: 8,
+    stringFrom: 2
+  }],
+  'D6/9': {
+    fret: 4,
+    stringFrom: 4,
+    stringTo: 3
+  }
+};
+
+function getFretCount(chord, fretLeftPadding = 0) {
+  let normalisedChord = chord.indexOf('-') > 1
+    ? chord.split('-')
+    : chord.split('');
+  const frets = normalisedChord
+    .filter((x) => x !== 'x')
+    .map((x) => +x)
+    .sort((a, b) => a - b);
+  return frets[frets.length - 1] - frets[0] + +fretLeftPadding + 1;
+}
+
 export default function chords() {
   document.querySelectorAll('.chords figure').forEach(el => {
     const {
@@ -10,8 +54,11 @@ export default function chords() {
       crop,
       showFretNumbers,
       fretLeftPadding,
-      mutedStrings
+      mutedStrings,
+      barred,
+      fretCount,
     } = el.dataset;
+
     const fretboard = new Fretboard({
       ...fretboardConfiguration,
       el,
@@ -21,15 +68,14 @@ export default function chords() {
       scaleFrets: false,
       stringWidth: 2,
       fretWidth: 2,
-      fretCount: 3,
+      fretCount: fretCount || getFretCount(chord, fretLeftPadding),
       dotSize: 25,
       dotStrokeWidth: 3,
       fretNumbersMargin: 30,
       showFretNumbers: !!showFretNumbers,
       fretLeftPadding: fretLeftPadding ? +fretLeftPadding : 0,
-      crop
-    }).renderChord(chord);
-
+      crop,
+    }).renderChord(chord, barred ? barres[name] : null);
     const figCaption = document.createElement('figcaption');
     figCaption.innerHTML = `${name}<br><code>${chord}</code>`;
     el.append(figCaption);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,7 +9,8 @@ export const DEFAULT_COLORS = {
     dotFill: 'white',
     fretNumber: '#00000099',
     mutedString: '#333',
-    dotText: '#111'
+    dotText: '#111',
+    barres: '#666'
 };
 
 export const DEFAULT_DIMENSIONS = {

--- a/src/fretboard/Fretboard.test.ts
+++ b/src/fretboard/Fretboard.test.ts
@@ -267,7 +267,7 @@ test('Fretboard renderChord()', t => {
   t.is(svg.querySelectorAll('.dots .dot').length, 3);
 });
 
-test('Fretboard renderChord() above 9th fret', t => {
+test('Fretboard renderChord() - above 9th fret', t => {
   const fretboard = new Fretboard();
   fretboard.renderChord('10-x-10-10-8-x');
 
@@ -275,6 +275,27 @@ test('Fretboard renderChord() above 9th fret', t => {
 
   t.is(svg.querySelectorAll('.muted-strings .muted-string').length, 2);
   t.is(svg.querySelectorAll('.dots .dot').length, 4);
+});
+
+test('Fretboard renderChord() - barres', t => {
+  const fretboard = new Fretboard();
+  fretboard.renderChord('133211', { fret: 1 });
+
+  const svg = document.querySelector('#fretboard svg');
+
+  t.is(svg.querySelectorAll('.barres rect').length, 1);
+});
+
+test('Fretboard renderChord() - multiple barres', t => {
+  const fretboard = new Fretboard();
+  fretboard.renderChord('x35553', [
+    { fret: 3, stringFrom: 5 },
+    { fret: 5, stringFrom: 4, stringTo: 2 }
+  ]);
+
+  const svg = document.querySelector('#fretboard svg');
+
+  t.is(svg.querySelectorAll('.barres rect').length, 2);
 });
 
 test('Fretboard renderBox()', t => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { Fretboard } from './fretboard/Fretboard';
+export { Fretboard, Position, Barre } from './fretboard/Fretboard';
 
 export {
   tetrachord,


### PR DESCRIPTION
Barres are now supported by passing either a single `Barre` parameter, or an array of them:

```typescript
type Barre = {
  fret: number;
  stringFrom?: number;
  stringTo?: number;
}

// renders a F major in first position
const fretboard = new Fretboard({
  fretCount: 3,
  showFretNumbers: false,
  crop: true
});

fretboard.renderChord('133211', { fret: 1 });

// renders a B minor in second position
const fretboard = new Fretboard({
  fretCount: 3,
  showFretNumbers: false,
  crop: true
});

fretboard.renderChord('x24432', { fret: 2, stringFrom: 5 });

// renders a C major in third position
const fretboard = new Fretboard({
  fretCount: 3,
  showFretNumbers: false,
  crop: true
});

fretboard.renderChord('x35553', [
  { fret: 3, stringFrom: 5 },
  { fret: 5, stringFrom: 4, stringTo: 2 }
]);
```
**Note:** `stringFrom` defaults to the lowest string, and `stringTo` to the first. Pass the "human" agreed value otherwise, e.g. 2 for the open B string, or 5 for the open A (in standard guitar tuning of course).

See examples and docs for further reference.

[Closes #21 ]