### PR TITLE
Update documentation link to point to the fretboard docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,4 @@ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH RE
 
 [homepage]: https://moonwave99.github.io/fretboard.js/
 [icon]: https://moonwave99.github.io/fretboard.js/assets/icon.svg
-[docs]: https://moonwave99.github.io/fretboard.js/documentation.html
+[docs]: https://moonwave99.github.io/fretboard.js/documentation-fretboard.html


### PR DESCRIPTION
:wave: Hi there.  

Thanks for the wonderful library!  I've been looking into fretboard.js for a few days now and noticed that I have been looking at an old version of the docs.   This updates the docs link to point to what I believe to be the newer docs.

🎸 