### PR TITLE
Prevent rendering dots greater than fret count

### DIFF
--- a/src/fretboard/Fretboard.test.ts
+++ b/src/fretboard/Fretboard.test.ts
@@ -166,6 +166,33 @@ test('Fretboard render twice', t => {
   t.is(svg.querySelectorAll('.dots .dot').length, pentaDots.length);
 });
 
+test('Fretboard render dot less than fret count', t => {
+  const fretboard = new Fretboard({ fretCount: 12 });
+  fretboard.setDots([{ fret: 11, string: 1 }]).render();
+
+  const svg = document.querySelector('#fretboard svg');
+
+  t.is(svg.querySelectorAll('.dots .dot').length, 1);
+});
+
+test('Fretboard render dot equal to fret count', t => {
+  const fretboard = new Fretboard({ fretCount: 12 });
+  fretboard.setDots([{ fret: 12, string: 1 }]).render();
+
+  const svg = document.querySelector('#fretboard svg');
+
+  t.is(svg.querySelectorAll('.dots .dot').length, 1);
+});
+
+test('Fretboard render dot greater than fret count', t => {
+  const fretboard = new Fretboard({ fretCount: 12 });
+  fretboard.setDots([{ fret: 13, string: 1 }]).render();
+
+  const svg = document.querySelector('#fretboard svg');
+
+  t.is(svg.querySelectorAll('.dots .dot').length, 0);
+});
+
 test('Fretboard clear', t => {
   const fretboard = new Fretboard();
   fretboard.setDots(pentaDots).render();

--- a/src/fretboard/Fretboard.ts
+++ b/src/fretboard/Fretboard.ts
@@ -271,7 +271,7 @@ export class Fretboard {
     const {
       wrapper,
       positions,
-      dots
+      options
     } = this;
 
     const {
@@ -290,6 +290,7 @@ export class Fretboard {
 
     wrapper.select('.dots').remove();
 
+    const dots = this.dots.filter(dot => dot.fret <= options.fretCount);
     if (!dots.length) {
       return this;
     }


### PR DESCRIPTION
This filter prevents `Fretboard.prototype.render` from attempting to render dots that are unrenderable due to their relationship with `fretCount`. Before this PR, trying to render unrenderable dots would cause `TypeError`s to be thrown. I'm unsure if/how to account for `dotOffset`.