### PR TITLE
Bug fixing in getPositionFromMouseCoords() for issue #27.

### DIFF
--- a/src/fretboard/utils.ts
+++ b/src/fretboard/utils.ts
@@ -151,6 +151,7 @@ export function getDimensions({
 type GetPositionParams = {
   event: MouseEvent;
   stringsGroup: Selection<BaseType, unknown, HTMLElement, unknown>;
+  topPadding: number;
   leftPadding: number;
   nutWidth: number;
   strings: number[];
@@ -161,6 +162,7 @@ type GetPositionParams = {
 export const getPositionFromMouseCoords = ({
   event,
   stringsGroup,
+  topPadding,
   leftPadding,
   nutWidth,
   strings,
@@ -173,14 +175,14 @@ export const getPositionFromMouseCoords = ({
   } = (stringsGroup.node() as HTMLElement).getBoundingClientRect();
   const bounds = (event.target as HTMLElement).getBoundingClientRect();
   const x = event.clientX - bounds.left;
-  const y = event.clientY - bounds.top;
+  const y = event.clientY - bounds.top - topPadding ;
 
   let foundString = 0;
 
-  const stringDistance = stringsGroupHeight / (strings.length - 1);
+  const halfStringDistance = stringsGroupHeight / ( 2 * (strings.length - 1) ) ;
 
   for (let i = 0; i < strings.length; i++) {
-    if (y < stringDistance * (i + 1)) {
+    if (y < halfStringDistance *  ( 1 + 2*i ) ) {
       foundString = i;
       break;
     }


### PR DESCRIPTION
I have made two changes:
 - pass topPadding into the function and subtract it from the Y position
 - compare the Y coordinate to 0.5, 1.5, ... times the string separation

Previously, the Y coordinate was compared to 1, 2, ... times the separation. I think this only worked, when topPadding was approximately half of the string separation.